### PR TITLE
tool to get databricks AD token

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -58,3 +58,26 @@ optional arguments:
   --cfg-file CFG_FILE   specify your configuration file if it differs from setup.cfg
   --reject REJECT       regex to exclude. Default: pip|pywin32
 ```
+
+# Azure Databricks AD Token
+
+If you want to use azure AD tokens to access the Databricks API
+(instead of the personal access tokens that you can pull from the
+web frontend), you can follow 
+[this guide here](https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/latest/aad/app-aad-token).
+Set the redirect URI to `localhost` exactly as in the example.
+
+After setting up the initial web-app for authentication, you can use 
+the command line tool provided by this package to get the token quickly.
+
+```
+$> atc_az_databricks_token --appId $appId --tenantId $tenantId --workspaceUrl $workspaceUrl
+```
+
+The parameters `appId` and `tenantId` correspond to the web-app that you registered.
+If no further parameters are given the databricks token will be printed to
+the console for use in your deployment pipeline.
+
+If you set the optional parameter `workspaceUrl`, the tool will instead 
+overwrite your `~/.databrickscfg` file with the provided workspace url
+and with the newly generated token.

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     atc-dataplatform
     pyyaml==6.0
     importlib_metadata
+    requests
 
 [options.packages.find]
 where=src
@@ -50,6 +51,7 @@ dev =
 [options.entry_points]
 console_scripts =
     atc_dp_freeze_req = atc_tools.requirements:main
+    atc_az_databricks_token = atc_tools.az_databricks_token.main:main
 
 
 [flake8]

--- a/src/atc_tools/az_databricks_token/AuthLinkOpener.py
+++ b/src/atc_tools/az_databricks_token/AuthLinkOpener.py
@@ -1,0 +1,37 @@
+import threading
+import time
+import uuid
+import webbrowser
+from urllib.parse import urlencode
+
+
+class AuthLinkOpener(threading.Thread):
+    def __init__(self, appId: str, tenantId: str, local_port: int):
+        super().__init__()
+        self.appId = appId
+        self.tenantId = tenantId
+        self.local_port = local_port
+        self.state = str(uuid.uuid4())
+        self.start()
+
+    def build_query(self):
+        url = (
+            f"https://login.microsoftonline.com/{self.tenantId}"
+            "/oauth2/v2.0/authorize?"
+        )
+        self.redirect_uri = f"http://localhost:{self.local_port}"
+        query = {
+            "client_id": self.appId,
+            "response_type": "code",
+            "redirect_uri": self.redirect_uri,
+            "response_mode": "query",
+            # fixed scope for Azure Databricks
+            "scope": "2ff814a6-3304-4ab8-85cb-cd0e6f879c1d/.default",
+            "state": self.state,
+        }
+
+        return url + urlencode(query)
+
+    def run(self) -> None:
+        time.sleep(2)
+        webbrowser.open(self.build_query())

--- a/src/atc_tools/az_databricks_token/__init__.py
+++ b/src/atc_tools/az_databricks_token/__init__.py
@@ -1,0 +1,20 @@
+"""
+This package implements the MSAL flow to obtain a personal api token for an instance
+of azure databricks without using the web interface.
+
+see url:
+https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/latest/aad/app-aad-token
+
+see also:
+https://docs.microsoft.com/en-us/azure/active-directory/develop/reply-url#localhost-exceptions
+
+Required input:
+- applicationId (for the auth application)
+- tenantId
+
+
+"""
+
+# from atc_tools.az_databricks_token.main import main
+# from atc_tools.az_databricks_token.server import LocalRequestHandler
+#

--- a/src/atc_tools/az_databricks_token/get_ad_access_token.py
+++ b/src/atc_tools/az_databricks_token/get_ad_access_token.py
@@ -1,0 +1,17 @@
+import requests
+
+
+def get_ad_access_token(
+    appId: str, tenantId: str, auth_code: str, state: str, redirect_uri: str
+):
+    url = f"https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/token"
+    data = dict(
+        client_id=appId,
+        scope="2ff814a6-3304-4ab8-85cb-cd0e6f879c1d/.default",
+        code=auth_code,
+        redirect_uri=redirect_uri,
+        grant_type="authorization_code",
+        state=state,
+    )
+    r = requests.post(url=url, data=data)
+    return (r.json())["access_token"]

--- a/src/atc_tools/az_databricks_token/get_impersonation_authorization_code.py
+++ b/src/atc_tools/az_databricks_token/get_impersonation_authorization_code.py
@@ -1,0 +1,31 @@
+import sys
+from types import SimpleNamespace
+
+from atc_tools.az_databricks_token.server import LocalServer
+from atc_tools.az_databricks_token.AuthLinkOpener import AuthLinkOpener
+
+
+def get_impersonation_authorization_code(appId: str, tenantId: str):
+    # to get the callback, launch a server on localhost
+    webServer = LocalServer()
+    print("Opening browser, please log in...", file=sys.stderr)
+
+    # open the webbrowser in another thread after two seconds.
+    opener = AuthLinkOpener(
+        appId=appId, tenantId=tenantId, local_port=webServer.server_port
+    )
+
+    # handle one request (blocking)
+    webServer.handle_request()
+
+    try:
+        result = webServer.last_query
+    except AttributeError:
+        raise Exception("No callback was received in time. Please re-try.")
+
+    if result.state != opener.state:
+        raise Exception("Invalid state field in result.")
+
+    return SimpleNamespace(
+        auth_code=result.code, state=opener.state, redirect_uri=opener.redirect_uri
+    )

--- a/src/atc_tools/az_databricks_token/main.py
+++ b/src/atc_tools/az_databricks_token/main.py
@@ -1,0 +1,50 @@
+import argparse
+from pathlib import Path
+
+from atc_tools.az_databricks_token.get_impersonation_authorization_code import (
+    get_impersonation_authorization_code,
+)
+from atc_tools.az_databricks_token.get_ad_access_token import get_ad_access_token
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Request Azure Databricks MSAL token.",
+        epilog="For more information see https://docs.microsoft.com"
+        "/en-us/azure/databricks/dev-tools/api/latest/aad/app-aad-token",
+    )
+    parser.add_argument("--appId", required=True, help="the authorizing webapp")
+    parser.add_argument("--tenantId", required=True, help="the tenant of the webapp")
+    parser.add_argument(
+        "--workspaceUrl", help="directly set .databrickscfg if this is given"
+    )
+
+    args = parser.parse_args()
+
+    # 1. Request an authorization code, which launches a browser window and asks
+    # for Azure user login. The authorization code is returned after the user
+    # successfully logs in.
+    results = get_impersonation_authorization_code(
+        appId=args.appId, tenantId=args.tenantId
+    )
+
+    # 2. Use the authorization code to acquire the Azure AD access token.
+    access_token = get_ad_access_token(
+        appId=args.appId,
+        tenantId=args.tenantId,
+        auth_code=results.auth_code,
+        state=results.state,
+        redirect_uri=results.redirect_uri,
+    )
+
+    if args.workspaceUrl:
+        dbcfg = (
+            "[DEFAULT]\n"
+            f"host = https://{args.workspaceUrl}\n"
+            f"token = {access_token}"
+        )
+        with open(Path.home() / ".databrickscfg", "w") as f:
+            f.write(dbcfg)
+        print("Your local .databrickscfg has been updated with a token.")
+    else:
+        print(access_token)

--- a/src/atc_tools/az_databricks_token/server.py
+++ b/src/atc_tools/az_databricks_token/server.py
@@ -1,0 +1,38 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from types import SimpleNamespace
+from urllib.parse import parse_qsl, urlparse
+
+
+class LocalRequestHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        # extract the callback query
+        self.server.last_query = SimpleNamespace(
+            **dict(parse_qsl(urlparse(self.path).query))
+        )
+
+        self.send_response(200)
+        self.send_header("Content-type", "text/html")
+        self.end_headers()
+        self.wfile.write(
+            bytes(
+                """<html><head><title>Deploy Script Databricks Login</title></head>
+                <body>
+                <h>Deploy Script Databricks Login</h>
+                <p>You can close this tab.</p>
+                </body></html>
+                """,
+                "utf-8",
+            )
+        )
+
+
+    def log_message(self, format, *args):
+        """We don't want the output that someone connected to us,
+        because the query contains a secret"""
+        pass
+
+
+class LocalServer(HTTPServer):
+    def __init__(self):
+        super().__init__(("localhost", 0), LocalRequestHandler)
+        self.timeout = 60


### PR DESCRIPTION
# Azure Databricks AD Token

If you want to use azure AD tokens to access the Databricks API
(instead of the personal access tokens that you can pull from the
web frontend), you can follow 
[this guide here](https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/latest/aad/app-aad-token).
Set the redirect URI to `localhost` exactly as in the example.

After setting up the initial web-app for authentication, you can use 
the command line tool provided by this package to get the token quickly.

```
$> atc_az_databricks_token --appId $appId --tenantId $tenantId --workspaceUrl $workspaceUrl
```

The parameters `appId` and `tenantId` correspond to the web-app that you registered.
If no further parameters are given the databricks token will be printed to
the console for use in your deployment pipeline.

If you set the optional parameter `workspaceUrl`, the tool will instead 
overwrite your `~/.databrickscfg` file with the provided workspace url
and with the newly generated token.