### PR TITLE
test handle

### DIFF
--- a/src/atc_tools/testing/TestHandle.py
+++ b/src/atc_tools/testing/TestHandle.py
@@ -1,0 +1,35 @@
+
+from atc.tables.TableHandle import TableHandle
+from pyspark.sql import DataFrame
+
+
+class TestHandle(TableHandle):
+    def __init__(self, provides:DataFrame = None):
+        self.provides = provides
+        self.overwritten = None
+        self.appended = None
+        self.truncated = False
+        self.dropped = False
+        self.dropped_and_deleted = False
+
+
+    def read(self) -> DataFrame:
+        if self.provides is not None:
+            return self.provides
+        else:
+            raise AssertionError("TableHandle not readable.")
+
+    def overwrite(self, df: DataFrame) -> None:
+        self.overwritten = df
+
+    def append(self, df: DataFrame) -> None:
+        self.appended = df
+
+    def truncate(self) -> None:
+        self.truncated = True
+
+    def drop(self) -> None:
+        self.dropped =True
+
+    def drop_and_delete(self) -> None:
+        self.dropped_and_deleted = True

--- a/src/atc_tools/testing/TestHandle.py
+++ b/src/atc_tools/testing/TestHandle.py
@@ -1,17 +1,15 @@
-
 from atc.tables.TableHandle import TableHandle
 from pyspark.sql import DataFrame
 
 
 class TestHandle(TableHandle):
-    def __init__(self, provides:DataFrame = None):
+    def __init__(self, provides: DataFrame = None):
         self.provides = provides
         self.overwritten = None
         self.appended = None
         self.truncated = False
         self.dropped = False
         self.dropped_and_deleted = False
-
 
     def read(self) -> DataFrame:
         if self.provides is not None:
@@ -29,7 +27,7 @@ class TestHandle(TableHandle):
         self.truncated = True
 
     def drop(self) -> None:
-        self.dropped =True
+        self.dropped = True
 
     def drop_and_delete(self) -> None:
         self.dropped_and_deleted = True

--- a/src/atc_tools/testing/__init__.py
+++ b/src/atc_tools/testing/__init__.py
@@ -1,1 +1,2 @@
 from .DataframeTestCase import DataframeTestCase  # noqa: F401
+from .TestHandle import TestHandle  # noqa: F401


### PR DESCRIPTION
This test handle can be substituted wherever a TableHandle is required. Very useful in unit tests.