### PR TITLE
Feature/test job submission

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -98,11 +98,43 @@ The command can submit a single job run, but additionally:
 
 ## How to submit
 
+Usage:
+```powershell
+usage: atc-test-job submit [-h] [--wheels WHEELS] --tests TESTS (--task TASK | --tasks-from TASKS_FROM) (--cluster CLUSTER | --cluster-file CLUSTER_FILE)
+                           [--sparklibs SPARKLIBS | --sparklibs-file SPARKLIBS_FILE] [--requirement REQUIREMENT | --requirements-file REQUIREMENTS_FILE] [--main-script MAIN_SCRIPT]    
+                           [--pytest-args PYTEST_ARGS] [--out-json OUT_JSON]
+
+Run Test Cases on databricks cluster.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --wheels WHEELS       The glob paths of all wheels under test.
+  --tests TESTS         Location of the tests folder. Will be sendt to databricks as a whole.
+  --task TASK           Single Test file or folder to execute.
+  --tasks-from TASKS_FROM
+                        path in test archive where each subfolder becomes a task.
+  --cluster CLUSTER     JSON document describing the cluster setup.
+  --cluster-file CLUSTER_FILE
+                        File with JSON document describing the cluster setup.
+  --sparklibs SPARKLIBS
+                        JSON document describing the spark dependencies.
+  --sparklibs-file SPARKLIBS_FILE
+                        File with JSON document describing the spark dependencies.
+  --requirement REQUIREMENT
+                        a python dependency, specified like for pip
+  --requirements-file REQUIREMENTS_FILE
+                        File with python dependencies, specified like for pip
+  --main-script MAIN_SCRIPT
+                        Your own test_main.py script file, to add custom functionality.
+  --pytest-args PYTEST_ARGS
+                        Additional arguments to pass to pytest in each test job.
+  --out-json OUT_JSON   File to store the RunID for future queries.
+```
 
 ```powershell
-atc_test_job submit `
+atc-test-job submit `
     --tests tests `
-    --folder cluster/job4 `
+    --tasks-from tests/cluster/job4 `
     --cluster-file cluster.json `
     --requirements-file requirements.txt `
     --sparklibs-file sparklibs.json `
@@ -154,6 +186,20 @@ atc_test_job submit `
   provided on the command line when fetching.
 
 ## How to fetch
+Usage:
+```powershell
+usage: atc-test-job fetch [-h] (--runid RUNID | --runid-json RUNID_JSON) [--stdout STDOUT] [--failfast]
+
+Return test run result.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --runid RUNID         Run ID of the test job
+  --runid-json RUNID_JSON
+                        File with JSON document describing the Run ID of the test job.
+  --stdout STDOUT       Output test stdout to this file.
+  --failfast            Stop and cancel job on first failed task.
+```
 
 The `fetch` operation consists of the following steps:
 - periodically query the job progress and print updates to the console.
@@ -165,7 +211,7 @@ The `fetch` operation consists of the following steps:
 
 Example fetch:
 ```powershell
-atc_test_job fetch --runid-json .\test.json --stdout .\stdout.txt
+atc-test-job fetch --runid-json .\test.json --stdout .\stdout.txt
 ```
 
 - The run ID can be supplied through a file or directly in the command line.

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,3 +81,93 @@ the console for use in your deployment pipeline.
 If you set the optional parameter `workspaceUrl`, the tool will instead 
 overwrite your `~/.databrickscfg` file with the provided workspace url
 and with the newly generated token.
+
+# Test Job submission
+
+The command `atc_test_job` can be used to run unit-test on a databricks cluster.
+The command can submit a single job run, but additionally:
+
+ - your unittests folder is archived and sent to databricks so that tests can be run 
+   on a cluster
+ - a main script is automatically pushed to databricks, so you don't have to supply 
+   your own
+ - At a specified level below your total tests-folder, the job is split into parallel 
+   tasks
+ - Test output is collected by using the cluster log functionality of databricks
+ - a fetch command can return all stdout
+
+## How to submit
+
+
+```powershell
+atc_test_job submit `
+    --tests tests `
+    --folder cluster/job4 `
+    --cluster-file cluster.json `
+    --requirements-file requirements.txt `
+    --sparklibs-file sparklibs.json `
+    --out-json test.json
+```
+
+- `tests/` should be the folder containing all your tests. In the test run, you will 
+  be able to reference it from the local folder `import tests.my.tool`
+- `cluster/job4` will be the part of the test library from which tests will be 
+  executed. In this example, the folder `tests/cluster/job4` exists. Its sub-folders 
+  will be executed in one task per subfolder inside the test job.
+- `cluster.json` should contain a cluster description for a job. Example
+```json
+{
+  "spark_version": "9.1.x-scala2.12",
+  "spark_conf": {
+    "spark.databricks.cluster.profile": "singleNode",
+    "spark.master": "local[*, 4]",
+    "spark.databricks.delta.preview.enabled": true,
+    "spark.databricks.io.cache.enabled":true
+  },
+  "azure_attributes": {
+    "availability": "ON_DEMAND_AZURE",
+    "first_on_demand": 1,
+    "spot_bid_max_price": -1
+  },
+  "node_type_id": "Standard_DS3_v2",
+  "custom_tags": {
+    "ResourceClass":"SingleNode"
+  },
+  "spark_env_vars": {
+    "PYSPARK_PYTHON": "/databricks/python3/bin/python3"
+  },
+  "num_workers": 0
+}
+```
+- the optional `requirements.txt` should contain a pip-style list of requirements
+- the optional `sparklibs.json` should contain spark dependencies as an array. Example:
+```json
+[
+    {
+        "maven": {
+            "coordinates": "com.microsoft.azure:spark-mssql-connector_2.12:1.2.0"
+        }
+    }
+]
+```
+- optionally, the run ID is written to `test.json` so that it does not have to be 
+  provided on the command line when fetching.
+
+## How to fetch
+
+The `fetch` operation consists of the following steps:
+- periodically query the job progress and print updates to the console.
+- if any task completes, the stdout file is downloaded
+- if `failfast` is selected, a single failed task will result in a cancelling of the 
+  overall job.
+- If the job succeeds, the command will return with 0 return value, making it 
+  suitable for use in test pipelines.
+
+Example fetch:
+```powershell
+atc_test_job fetch --runid-json .\test.json --stdout .\stdout.txt
+```
+
+- The run ID can be supplied through a file or directly in the command line.
+- if `stdout` is set, the output will be written to this file instead of printing to 
+  the console.

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
     importlib_metadata
     requests
     dateparser
+    pytest
 
 [options.packages.find]
 where=src
@@ -53,6 +54,7 @@ dev =
 console_scripts =
     atc_dp_freeze_req = atc_tools.requirements:main
     atc_az_databricks_token = atc_tools.az_databricks_token.main:main
+    atc_test_job = atc_tools.test_job.main:main
 
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ dev =
 console_scripts =
     atc_dp_freeze_req = atc_tools.requirements:main
     atc_az_databricks_token = atc_tools.az_databricks_token.main:main
-    atc_test_job = atc_tools.test_job.main:main
+    atc-test-job = atc_tools.test_job.main:main
 
 
 [flake8]

--- a/src/atc_tools/test_job/RunDetails.py
+++ b/src/atc_tools/test_job/RunDetails.py
@@ -1,0 +1,57 @@
+import subprocess
+import tempfile
+import time
+
+from atc_tools.test_job import test_main
+from atc_tools.test_job.dbcli import dbjcall, dbcall, dbfscall
+from atc_tools.test_job.dbfs import DbfsLocation
+
+class DbfsFileDoesNotExist(Exception):
+    pass
+
+class RunDetails:
+    details: dict
+
+    def __init__(self, run_id: int):
+        self.run_id = run_id
+        self.refresh()
+        print(f"Job details: {self.details['run_page_url']}")
+
+    def refresh(self):
+        self.details = dbjcall(f"runs get --run-id {self.run_id}")
+
+    def cancel(self):
+        dbcall(f"runs cancel --run-id {self.run_id}")
+
+    def get_stdout(self, task_key: str) -> str:
+        print(f"Getting stdut for {task_key}")
+        (task,) = [t for t in self.details["tasks"] if t["task_key"] == task_key]
+        log_destination = task["new_cluster"]["cluster_log_conf"]["dbfs"]["destination"]
+        cluster_instance = task["cluster_instance"]["cluster_id"]
+        print(log_destination, cluster_instance)
+        log_stout_path = f"{log_destination}/{cluster_instance}/driver/stdout"
+        with tempfile.TemporaryDirectory() as tmp:
+
+            try:
+                self.wait_until_exists(log_stout_path)
+            except:
+                return f"-=ERROR FETCHING LOG FILES FROM  {log_stout_path}=-"
+
+            dbfscall(f"cp {log_stout_path} {tmp}/stdout")
+            with open(f'{tmp}/stdout', encoding='utf-8') as f:
+                lines=iter(f)
+                for l in lines:
+                    if l.strip() == test_main.marker:
+                        break
+                return "\n".join(lines)
+
+    def wait_until_exists(self, location:str, tries=20, sleep_s = 1):
+        for i in range(tries):
+            try:
+                dbfscall(f"ls {location}")
+                return
+            except subprocess.CalledProcessError:
+                time.sleep(sleep_s)
+
+        raise DbfsFileDoesNotExist()
+

--- a/src/atc_tools/test_job/RunDetails.py
+++ b/src/atc_tools/test_job/RunDetails.py
@@ -4,12 +4,15 @@ import time
 
 from atc_tools.test_job import test_main
 from atc_tools.test_job.dbcli import dbjcall, dbcall, dbfscall
-from atc_tools.test_job.dbfs import DbfsLocation
+
 
 class DbfsFileDoesNotExist(Exception):
     pass
 
+
 class RunDetails:
+    """Object representing the details of a job run"""
+
     details: dict
 
     def __init__(self, run_id: int):
@@ -18,13 +21,16 @@ class RunDetails:
         print(f"Job details: {self.details['run_page_url']}")
 
     def refresh(self):
+        """refresh the internal details by querying databricks"""
         self.details = dbjcall(f"runs get --run-id {self.run_id}")
 
     def cancel(self):
+        """Cancel the run on databricks."""
         dbcall(f"runs cancel --run-id {self.run_id}")
 
     def get_stdout(self, task_key: str) -> str:
-        print(f"Getting stdut for {task_key}")
+        """Return the driver stdout from the cluster logs."""
+        print(f"Getting stdout for {task_key}")
         (task,) = [t for t in self.details["tasks"] if t["task_key"] == task_key]
         log_destination = task["new_cluster"]["cluster_log_conf"]["dbfs"]["destination"]
         cluster_instance = task["cluster_instance"]["cluster_id"]
@@ -38,14 +44,17 @@ class RunDetails:
                 return f"-=ERROR FETCHING LOG FILES FROM  {log_stout_path}=-"
 
             dbfscall(f"cp {log_stout_path} {tmp}/stdout")
-            with open(f'{tmp}/stdout', encoding='utf-8') as f:
-                lines=iter(f)
+            with open(f"{tmp}/stdout", encoding="utf-8") as f:
+                lines = iter(f)
                 for l in lines:
                     if l.strip() == test_main.marker:
                         break
                 return "\n".join(lines)
 
-    def wait_until_exists(self, location:str, tries=20, sleep_s = 1):
+    def wait_until_exists(self, location: str, tries=20, sleep_s=1):
+        """Wait until the file exists on dbfs."""
+        # sometimes cluster logs do not appear immediately.
+        # TODO: expose the wait parameters on the cli
         for i in range(tries):
             try:
                 dbfscall(f"ls {location}")
@@ -54,4 +63,3 @@ class RunDetails:
                 time.sleep(sleep_s)
 
         raise DbfsFileDoesNotExist()
-

--- a/src/atc_tools/test_job/dbcli.py
+++ b/src/atc_tools/test_job/dbcli.py
@@ -1,0 +1,57 @@
+import json
+import subprocess
+import sys
+
+
+def db_check():
+    try:
+        import databricks_cli
+    except ImportError:
+        print("Databricks CLI is not installed", file=sys.stderr)
+        exit(-1)
+
+    try:
+        dbjcall("clusters list  --output=JSON")
+    except subprocess.CalledProcessError:
+        print(
+            "Could not query databricks state. Is your token up to date?",
+            file=sys.stderr,
+        )
+        exit(-1)
+    dbcall("jobs configure --version=2.1")
+
+def dbjcall(command: str):
+    p = subprocess.run(
+        "databricks " + command ,
+        shell=True,
+        stdout=subprocess.PIPE,
+        check=True,
+        text=True,
+    )
+    try:
+        return json.loads(p.stdout)
+    except:
+        print(p.stdout)
+        raise
+
+
+def dbfscall(command: str):
+    p = subprocess.run(
+        "dbfs " + command,
+        shell=True,
+        stdout=subprocess.PIPE,
+        check=True,
+        text=True,
+    )
+    return p.stdout
+
+
+def dbcall(command: str):
+    p = subprocess.run(
+        "databricks " + command,
+        shell=True,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    return p.stdout

--- a/src/atc_tools/test_job/dbcli.py
+++ b/src/atc_tools/test_job/dbcli.py
@@ -4,6 +4,10 @@ import sys
 
 
 def db_check():
+    """check that the databricks cli is correctly configured
+    and has an up-to-date authorization token.
+    Returns Nothing.
+    Ends the program if this check fails."""
     try:
         import databricks_cli
     except ImportError:
@@ -20,9 +24,11 @@ def db_check():
         exit(-1)
     dbcall("jobs configure --version=2.1")
 
+
 def dbjcall(command: str):
+    """Run the command line "databricks "+command and return the unpacked json string."""
     p = subprocess.run(
-        "databricks " + command ,
+        "databricks " + command,
         shell=True,
         stdout=subprocess.PIPE,
         check=True,
@@ -36,6 +42,7 @@ def dbjcall(command: str):
 
 
 def dbfscall(command: str):
+    """Run the command line "dbfs "+command and return the output string."""
     p = subprocess.run(
         "dbfs " + command,
         shell=True,
@@ -47,6 +54,7 @@ def dbfscall(command: str):
 
 
 def dbcall(command: str):
+    """Run the command line "databricks "+command and return the resulting string."""
     p = subprocess.run(
         "databricks " + command,
         shell=True,

--- a/src/atc_tools/test_job/dbfs.py
+++ b/src/atc_tools/test_job/dbfs.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class DbfsLocation:
+    remote: str = ""
+    local: str = ""
+
+    def __truediv__(self, value)->"DbfsLocation":
+        return DbfsLocation(remote=self.remote+"/"+value, local=self.local+"/"+value)
+
+    @classmethod
+    def from_str(cls, val:str)->"DbfsLocation":
+        result = cls()
+        if val.startswith("dbfs:/"):
+            result.set_remote(val)
+        elif val.startswith("/dbfs/"):
+            result.set_local()
+        else:
+            raise ValueError("Invalid dbfs path")
+    def set_remote(self, remote:str)->None:
+        if not remote.startswith("dbfs:/"):
+            raise AssertionError("Remote locations must start with dbfs:/")
+        self.local = "/dbfs/" +remote[6:]
+        self.remote = remote
+
+    def set_local(self, local:str)->None:
+        if not local.startswith("/dbfs/"):
+            raise AssertionError("Local locations must start with /dbfs/")
+        self.remote = "dbfs:/" +local[6:]
+        self.local = local

--- a/src/atc_tools/test_job/fetch.py
+++ b/src/atc_tools/test_job/fetch.py
@@ -1,0 +1,170 @@
+"""
+- find the test job (by ID or discover by tag)
+- get job status:
+- tasks: pending: 0 running: 0 success: 0 failed: 0
+- any time a task finishes, print the log
+- add a fail_fast so that any time a task fails, job is cancelled
+"""
+import argparse
+import json
+import sys
+import time
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import IO, List, Optional
+
+from atc_tools.test_job.RunDetails import RunDetails
+from atc_tools.test_job.dbcli import db_check
+
+def setup_fetch_parser(subparsers):
+    parser: argparse.ArgumentParser = subparsers.add_parser(
+        "fetch",
+        description="Return test run result."
+    )
+    parser.set_defaults(func=fetch_main)
+
+    # cluster argument pair
+    runid_config = parser.add_mutually_exclusive_group(required=True)
+    runid_config.add_argument(
+        "--runid",
+        type=int,
+        help="Run ID of the test job",
+        default=None,
+    )
+    runid_config.add_argument(
+        "--runid-json",
+        type=argparse.FileType("r"),
+        help="File with JSON document describing the Run ID of the test job.",
+        default=None,
+    )
+
+    parser.add_argument(
+        "--stdout",
+        type=argparse.FileType("w"),
+        required=False,
+        help="Output test stdout to this file.",
+        default=None,
+    )
+
+    parser.add_argument(
+        "--failfast",
+        action="store_true",
+        help="Stop and cancel job on first failed task.",
+    )
+
+def collect_args(args):
+    if args.runid is None:
+        args.runid = json.load(args.runid_json)["run_id"]
+
+    return args
+
+def fetch_main(args):
+    db_check()
+
+    args = collect_args(args)
+
+    if fetch(args.runid, args.stdout, args.failfast):
+        print("Run failed")
+        sys.exit(-1)
+
+@dataclass
+class TaskState:
+    task_key: str
+    life_cycle_state: str
+    result_state: str
+    end_time: int
+
+    @property
+    def ended(self):
+        return self.end_time != 0
+
+    @property
+    def result(self):
+        if not self.ended:
+            return self.life_cycle_state
+        else:
+            return self.result_state
+
+    @property
+    def success(self):
+        return self.result_state.upper() == "SUCCESS"
+
+    @classmethod
+    def fromJson(cls, jobj):
+        state = jobj["state"]
+        return cls(
+            task_key=jobj["task_key"] if "task_key" in jobj else jobj["run_name"],
+            life_cycle_state=state["life_cycle_state"],
+            result_state=state["result_state"] if "result_state" in state else "",
+            end_time=jobj["end_time"] if "end_time" in jobj else 0,
+        )
+
+
+@dataclass
+class MultiTaskState:
+    overall: Optional[TaskState]
+    tasks: List[TaskState]
+
+    @classmethod
+    def fromJson(cls, jobj):
+        return cls(
+            overall=TaskState.fromJson(jobj),
+            tasks=[TaskState.fromJson(task) for task in jobj["tasks"]],
+        )
+
+
+    def accumulate(self):
+        counts = defaultdict(int)
+        for task in self.tasks:
+            counts[task.result] += 1
+        return counts
+
+    def print_status(self):
+        print(
+            "Overall state:",
+            self.overall.result,
+            "| Task states:",
+            " | ".join(f"{k}: {v}" for k, v in self.accumulate().items()),
+        )
+
+
+def fetch(run_id: int, stdout_file: IO[str] = None, failfast=False):
+    run = RunDetails(run_id)
+    last_state = None
+    stdouts = {}
+    while True:
+        state = MultiTaskState.fromJson(run.details)
+        if last_state is None or state != last_state:
+            last_state = state
+            state.print_status()
+
+        if failfast:
+            if any(task.ended and not task.success for task in state.tasks):
+                break
+
+        for task in state.tasks:
+            if task.ended and task.task_key not in stdouts:
+                out = run.get_stdout(task.task_key)
+                if stdout_file is None:
+                    print(out)
+                stdouts[task.task_key]=out
+
+
+        if state.overall.ended:
+            break
+        time.sleep(5)
+        run.refresh()
+
+    if stdout_file is not None:
+        for k,v in stdouts.items():
+            stdout_file.write("="*50+f"\nTask Output from {k}\n"+"="*50+"\n")
+            stdout_file.write(v)
+
+    if last_state.overall.success:
+        print("Run result SUCCESS!")
+        return 0
+    else:
+        if not (last_state.overall.ended):
+            print("A task failed. Cancelling test run.")
+            run.cancel()
+        return 1

--- a/src/atc_tools/test_job/main.py
+++ b/src/atc_tools/test_job/main.py
@@ -5,15 +5,15 @@ from atc_tools.test_job.submit import setup_submit_parser
 
 
 def main():
+    """Cli main function. Not for use from python."""
     parser = argparse.ArgumentParser(
         description="Run Test Cases on databricks cluster."
     )
 
-    subparsers = parser.add_subparsers(required=True, dest='command')
+    subparsers = parser.add_subparsers(required=True, dest="command")
 
     setup_submit_parser(subparsers)
     setup_fetch_parser(subparsers)
 
     args = parser.parse_args()
     args.func(args)
-

--- a/src/atc_tools/test_job/main.py
+++ b/src/atc_tools/test_job/main.py
@@ -1,0 +1,19 @@
+import argparse
+
+from atc_tools.test_job.fetch import setup_fetch_parser
+from atc_tools.test_job.submit import setup_submit_parser
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run Test Cases on databricks cluster."
+    )
+
+    subparsers = parser.add_subparsers(required=True, dest='command')
+
+    setup_submit_parser(subparsers)
+    setup_fetch_parser(subparsers)
+
+    args = parser.parse_args()
+    args.func(args)
+

--- a/src/atc_tools/test_job/submit.py
+++ b/src/atc_tools/test_job/submit.py
@@ -1,0 +1,306 @@
+"""
+- test the databricks api token
+- zip the test archive
+- walk the test folders to determine the parallelization
+- constuct the test job json
+    - tag the test job for easy retrieval
+- submit the test job
+- return the ID - also to file
+"""
+import argparse
+import copy
+import datetime
+import inspect
+import json
+import subprocess
+import sys
+import tempfile
+import uuid
+
+from pathlib import Path
+import shutil
+from typing import List
+
+from typing.io import IO
+
+from . import test_main
+from .dbcli import dbjcall, dbfscall, dbcall, db_check
+from .dbfs import DbfsLocation
+
+
+def setup_submit_parser(subparsers):
+    parser: argparse.ArgumentParser = subparsers.add_parser(
+        "submit",
+        description="Run Test Cases on databricks cluster."
+    )
+    parser.set_defaults(func=submit_main)
+
+    parser.add_argument(
+        "--wheels",
+        type=str,
+        required=False,
+        help="The glob paths of all wheels under test.",
+        default="dist/*.whl",
+    )
+
+    parser.add_argument(
+        "--tests",
+        type=str,
+        required=True,
+        help="Location of the tests folder. Will be sendt to databricks as a whole.",
+    )
+
+    parser.add_argument(
+        "--folder",
+        type=str,
+        required=False,
+        default="",
+        help="relative path of test folder in test archive to use in task discovery.",
+    )
+
+    parser.add_argument(
+        "--out-json",
+        type=argparse.FileType("w"),
+        required=False,
+        help="File to store the RunID for future queries.",
+        default=None,
+    )
+
+    # cluster argument pair
+    cluster = parser.add_mutually_exclusive_group(required=True)
+    cluster.add_argument(
+        "--cluster",
+        type=str,
+        help="JSON document describing the cluster setup.",
+        default=None,
+    )
+    cluster.add_argument(
+        "--cluster-file",
+        type=argparse.FileType("r"),
+        help="File with JSON document describing the cluster setup.",
+        default=None,
+    )
+
+    # spark libraries argument pair
+    sparklibs = parser.add_mutually_exclusive_group(required=False)
+    sparklibs.add_argument(
+        "--sparklibs",
+        type=str,
+        help="JSON document describing the spark dependencies.",
+        default=None,
+    )
+    sparklibs.add_argument(
+        "--sparklibs-file",
+        type=argparse.FileType("r"),
+        help="File with JSON document describing the spark dependencies.",
+        default=None,
+    )
+
+    # python dependencies file
+    pydep = parser.add_mutually_exclusive_group(required=False)
+    pydep.add_argument(
+        "--requirement",
+        action="append",
+        help="a python dependency, specified like for pip",
+        default=[],
+    )
+    pydep.add_argument(
+        "--requirements-file",
+        type=argparse.FileType("r"),
+        help="File with python dependencies, specified like for pip",
+        default=None,
+    )
+    return
+
+def collect_arguments(args):
+    # pre-process 'cluster'
+    if args.cluster_file:
+        args.cluster = args.cluster_file.read()
+    args.cluster = json.loads(args.cluster)
+
+    # pre-process 'sparklibs'
+    if args.sparklibs_file:
+        args.sparklibs = args.sparklibs_file.read()
+    if args.sparklibs:
+        args.sparklibs = json.loads(args.sparklibs)
+
+    # pre-process 'requirement'
+    if args.requirements_file:
+        args.requirement = [
+            l.strip()
+            for l in args.requirements_file.read().splitlines()
+            if l.strip() and not l.strip().startswith("#")
+        ]
+
+
+    return args
+
+
+def submit_main(args):
+    db_check()
+
+    args = collect_arguments(args)
+
+    submit(
+        test_path=args.tests,
+        folder=args.folder,
+        cluster=args.cluster,
+        wheels=args.wheels,
+        requirement=args.requirement,
+        sparklibs=args.sparklibs,
+        out_json=args.out_json,
+    )
+
+
+class DbTestFolder:
+    def __init__(self):
+        test_folder = "/".join(
+            [
+                "test",
+                datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d-%H%M%S"),
+                uuid.uuid4().hex,
+            ]
+        )
+        self._test_path_base = DbfsLocation(
+            remote=f"dbfs:/{test_folder}", local=f"/dbfs/{test_folder}"
+        )
+
+    def __enter__(self):
+        print(f"Making dbfs test folder {self._test_path_base.remote}")
+        dbfscall(f"mkdirs {self._test_path_base.remote}")
+        return self._test_path_base
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+
+def discover_job_tasks(test_path: str, folder: str):
+
+    subfolders = [
+        x.as_posix() for x in (Path(test_path) / folder).iterdir() if x.is_dir()
+    ]
+    return subfolders
+
+
+def discover_and_push_wheels(globpath: str, test_folder: DbfsLocation) -> List[str]:
+    result = []
+    for item in Path().glob(globpath):
+        remote_path =f'{test_folder.remote}/{item.parts[-1]}'
+        print(f'pushing {item} to to test folder')
+        dbfscall(f"cp {item} {remote_path}")
+        result.append(remote_path)
+
+    return result
+
+def archive_and_push(test_path:str, test_folder: DbfsLocation):
+    with tempfile.TemporaryDirectory() as tmp:
+        test_path = Path(test_path)
+        print(f"now archiving {test_path}")
+        archive_path = shutil.make_archive(
+            str(Path(tmp) / "tests"),
+            "zip",
+            test_path / "..",
+            base_dir=test_path.parts[-1],
+        )
+        print("now pushing test archive to test folder")
+
+        dbfscall(f"cp {archive_path} {test_folder.remote}/tests.zip")
+
+    return f"{test_folder.local}/tests.zip"
+
+def push_main_file(test_folder: DbfsLocation)-> DbfsLocation:
+    print('now pushing test main file')
+    main_file = test_folder / 'main.py'
+    with tempfile.TemporaryDirectory() as tmp:
+        with open(Path(tmp) / "main.py", "w") as f:
+            f.write(inspect.getsource(test_main))
+
+        dbfscall(f"cp {tmp}/main.py {main_file.remote}")
+
+    return main_file
+
+def submit(
+    test_path: str,
+    folder: str,
+    cluster: dict,
+    wheels: str,
+    requirement: List[str] = None,
+    sparklibs: List[dict] = None,
+    out_json: IO[str] = None,
+):
+    if requirement is None:
+        requirement = []
+    if sparklibs is None:
+        sparklibs=[]
+
+    # check the structure of the cluster object
+    if not isinstance(cluster, dict):
+        raise AssertionError("invalid cluster specification")
+
+    # check the structure of the sparklibs object
+    if not isinstance(sparklibs, list):
+        raise AssertionError("invalid sparklibs specification")
+
+    for py_requirement in requirement:
+        sparklibs.append({"pypi": {"package": py_requirement}})
+
+    with DbTestFolder() as test_folder:
+        for wheel in discover_and_push_wheels(wheels, test_folder):
+            sparklibs.append({"whl": wheel})
+
+        archive_local = archive_and_push(test_path, test_folder)
+        main_file = push_main_file(test_folder)
+
+        print(f"copied everything to {test_folder.remote}")
+
+        # construct the workflow object
+        workflow = dict(run_name="Testing Run", format="MULTI_TASK", tasks=[])
+
+        # subtasks will be ['tests/cluster/job1', 'tests/cluster/job2'] or similar
+        for task in discover_job_tasks(test_path, folder):
+            task_sub = task.replace("/","_")
+            task_cluster = copy.deepcopy(cluster)
+            task_cluster['cluster_log_conf']={'dbfs':{'destination':f"{test_folder.remote}/{task_sub}"}}
+
+            workflow["tasks"].append(
+
+
+                dict(
+                    task_key=task_sub,
+                    libraries=sparklibs,
+                    spark_python_task=dict(
+                        python_file=main_file.remote,
+                        parameters=[
+                            # running in the spark python interpreter, the python __file__ variable does not
+                            # work. Hence, we need to tell the script where the test area is.
+                            f"--basedir={test_folder.local}/{task_sub}",
+                            # all tests will be unpacked from here
+                            f"--archive={archive_local}",
+                            # we can actually run any part of out test suite, but some files need the full repo.
+                            # Only run tests from this folder.
+                            f"--folder={task}",
+                        ],
+                    ),
+                    new_cluster=task_cluster
+                )
+            )
+    with tempfile.TemporaryDirectory() as tmp:
+        jobfile = f"{tmp}/job.json"
+        with open(jobfile, 'w') as f:
+            json.dump(workflow,f)
+        # with open(jobfile) as f:
+        #     print(f.read())
+        res = dbjcall(f"runs submit --json-file {jobfile}")
+        try:
+            run_id=res["run_id"]
+        except KeyError:
+            print(res)
+            raise
+
+    # now we have the run_id
+    print(f"Started run with ID {run_id}")
+    details = dbjcall(f'runs get --run-id {run_id}')
+    print(f"Follow job details at {details['run_page_url']}")
+
+    if out_json:
+        json.dump({'run_id':run_id},out_json)

--- a/src/atc_tools/test_job/submit.py
+++ b/src/atc_tools/test_job/submit.py
@@ -289,7 +289,7 @@ def submit(
                             f"--basedir={test_folder.local}/{task_sub}",
                             # all tests will be unpacked from here
                             f"--archive={archive_local}",
-                            # we can actually run any part of out test suite, but some files need the full repo.
+                            # we can actually run any part of our test suite, but some files need the full repo.
                             # Only run tests from this folder.
                             f"--folder={task}",
                         ],

--- a/src/atc_tools/test_job/test_main.py
+++ b/src/atc_tools/test_job/test_main.py
@@ -1,0 +1,45 @@
+import argparse
+import os
+import shutil
+import sys
+from hashlib import sha1
+
+import pytest
+from atc.spark import Spark
+
+# print a marker message to screen to mark the start of python output
+# make it invisible using only "\u200E\u200F\u2060" https://invisible-characters.com/
+marker = "".join(list("\u200E\u200F\u2060")[i % 3] for i in sha1(b"my marker").digest())
+
+def test_main():
+    parser = argparse.ArgumentParser(description="Run Test Cases.")
+
+    # location to use for current run. Usually the cluster logs base folder
+    parser.add_argument("--basedir")
+    # relative path of test folder in test archive
+    parser.add_argument("--folder")
+    # archive of test files to use
+    parser.add_argument("--archive")
+
+    args = parser.parse_args()
+
+    # move to basedir so that simple imports from one test to another work
+    os.chdir(args.basedir)
+    sys.path = [os.getcwd()] + sys.path
+
+    # unzip test archive to base folder
+    shutil.unpack_archive(args.archive)
+
+    # Ensure Spark is initialized before any tests are run
+    Spark.get()
+
+    print()
+    print(marker)
+    print()
+
+    retcode = pytest.main(["-x", args.folder])
+    if retcode.value:
+        raise Exception("Pytest failed")
+
+if __name__ == "__main__":
+    test_main()

--- a/src/atc_tools/test_job/test_main.py
+++ b/src/atc_tools/test_job/test_main.py
@@ -1,4 +1,14 @@
+"""
+This is the default main file that is pushed to databricks to launch the test task.
+Its tasks are
+- to unpack the test archive,
+- print a sequence of marker characters to identify the start
+  of python executing in the output
+- run the tests using pytest
+This file is not intended to be used directly.
+"""
 import argparse
+import json
 import os
 import shutil
 import sys
@@ -11,17 +21,25 @@ from atc.spark import Spark
 # make it invisible using only "\u200E\u200F\u2060" https://invisible-characters.com/
 marker = "".join(list("\u200E\u200F\u2060")[i % 3] for i in sha1(b"my marker").digest())
 
+
 def test_main():
     parser = argparse.ArgumentParser(description="Run Test Cases.")
 
     # location to use for current run. Usually the cluster logs base folder
     parser.add_argument("--basedir")
+
     # relative path of test folder in test archive
     parser.add_argument("--folder")
+
     # archive of test files to use
     parser.add_argument("--archive")
 
+    # archive of test files to use
+    parser.add_argument("--pytestargs")
+
     args = parser.parse_args()
+
+    extra_args = json.loads(args.pytestargs)
 
     # move to basedir so that simple imports from one test to another work
     os.chdir(args.basedir)
@@ -37,9 +55,10 @@ def test_main():
     print(marker)
     print()
 
-    retcode = pytest.main(["-x", args.folder])
+    retcode = pytest.main(["-x", args.folder, *extra_args])
     if retcode.value:
         raise Exception("Pytest failed")
+
 
 if __name__ == "__main__":
     test_main()

--- a/src/atc_tools/test_job/test_main.py
+++ b/src/atc_tools/test_job/test_main.py
@@ -23,6 +23,7 @@ marker = "".join(list("\u200E\u200F\u2060")[i % 3] for i in sha1(b"my marker").d
 
 
 def test_main():
+    """Main function to be called inside the test job task. Do not use directly."""
     parser = argparse.ArgumentParser(description="Run Test Cases.")
 
     # location to use for current run. Usually the cluster logs base folder


### PR DESCRIPTION
About this PR.
This is a generalization of a pattern that we have been using for a long time in a project.
There are no unit-tests because this needs a databricks to use, which is not available in this pipeline.
I have tested it manually against my own databricks instance.

---

# Test Job submission

The command `atc_test_job` can be used to run unit-test on a databricks cluster.
The command can submit a single job run, but additionally:

 - your unittests folder is archived and sent to databricks so that tests can be run 
   on a cluster
 - a main script is automatically pushed to databricks, so you don't have to supply 
   your own
 - At a specified level below your total tests-folder, the job is split into parallel 
   tasks
 - Test output is collected by using the cluster log functionality of databricks
 - a fetch command can return all stdout

## How to submit


```powershell
atc_test_job submit `
    --tests tests `
    --folder cluster/job4 `
    --cluster-file cluster.json `
    --requirements-file requirements.txt `
    --sparklibs-file sparklibs.json `
    --out-json test.json
```

- `tests/` should be the folder containing all your tests. In the test run, you will 
  be able to reference it from the local folder `import tests.my.tool`
- `cluster/job4` will be the part of the test library from which tests will be 
  executed. In this example, the folder `tests/cluster/job4` exists. Its sub-folders 
  will be executed in one task per subfolder inside the test job.
- `cluster.json` should contain a cluster description for a job. Example
```json
{
  "spark_version": "9.1.x-scala2.12",
  "spark_conf": {
    "spark.databricks.cluster.profile": "singleNode",
    "spark.master": "local[*, 4]",
    "spark.databricks.delta.preview.enabled": true,
    "spark.databricks.io.cache.enabled":true
  },
  "azure_attributes": {
    "availability": "ON_DEMAND_AZURE",
    "first_on_demand": 1,
    "spot_bid_max_price": -1
  },
  "node_type_id": "Standard_DS3_v2",
  "custom_tags": {
    "ResourceClass":"SingleNode"
  },
  "spark_env_vars": {
    "PYSPARK_PYTHON": "/databricks/python3/bin/python3"
  },
  "num_workers": 0
}
```
- the optional `requirements.txt` should contain a pip-style list of requirements
- the optional `sparklibs.json` should contain spark dependencies as an array. Example:
```json
[
    {
        "maven": {
            "coordinates": "com.microsoft.azure:spark-mssql-connector_2.12:1.2.0"
        }
    }
]
```
- optionally, the run ID is written to `test.json` so that it does not have to be 
  provided on the command line when fetching.

## How to fetch

The `fetch` operation consists of the following steps:
- periodically query the job progress and print updates to the console.
- if any task completes, the stdout file is downloaded
- if `failfast` is selected, a single failed task will result in a cancelling of the 
  overall job.
- If the job succeeds, the command will return with 0 return value, making it 
  suitable for use in test pipelines.

Example fetch:
```powershell
atc_test_job fetch --runid-json .\test.json --stdout .\stdout.txt
```

- The run ID can be supplied through a file or directly in the command line.
- if `stdout` is set, the output will be written to this file instead of printing to 
  the console.